### PR TITLE
Additional handlers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const testAdditionalHandlers = {
     $url: (path: string[]) => path.join('/')
 }
 
-console.log(tp<TestType, typeof testAdditionalHandlers>(testAdditionalHandlers).a.b.c.$abs.$url); // this will output "a/b/c"
+console.log(tp<TestType, typeof testAdditionalHandlers>(testAdditionalHandlers).a.b.c.$abs.$url); // this will output "/a/b/c"
 ```
 
 --- 

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -17,6 +17,11 @@ type TestType = {
     }
 };
 
+const testExtendedHandlers = {
+    $abs: (path: string[]) => typedPath<TestType, typeof testExtendedHandlers>(['', ...path], testExtendedHandlers),
+    $url: (path: string[]) => path.join('/')
+}
+
 describe('Typed path', () => {
     it('should get field path', () => {
         expect(typedPath<TestType>().a.b.c.$path).to.equal('a.b.c');
@@ -60,4 +65,12 @@ describe('Typed path', () => {
     it('should get path for valueOf()', () => {
         expect(tp<TestType>().a.b.f[3].blah.path.valueOf()).to.equal('a.b.f[3].blah.path');
     });
+
+    it('should work with extended handlers', () => {
+        expect(tp<TestType, typeof testExtendedHandlers>([], testExtendedHandlers).a.b.c.$url).to.equal('a/b/c');
+    })
+
+    it('should work with chained extended handlers', () => {
+        expect(tp<TestType, typeof testExtendedHandlers>([], testExtendedHandlers).a.b.c.$abs.$url).to.equal('/a/b/c');
+    })
 });

--- a/index.ts
+++ b/index.ts
@@ -48,11 +48,8 @@ export function typedPath<T, K extends TypedPathHandlersConfig = Record<never, n
         get(target: T, name: TypedPathKey) {
             const handlersConfig: TypedPathHandlersConfig = { ...(additionalHandlers ?? {}), ...defaultHandlersConfig };
 
-            const keys: (keyof typeof handlersConfig)[] = Object.keys(handlersConfig);
-            for (const key of keys) {
-                if (key === name) {
-                    return handlersConfig[key](path, additionalHandlers);
-                }
+            if (handlersConfig.hasOwnProperty(name)) {
+                return handlersConfig[name as any](path, additionalHandlers);
             }
 
             return typedPath([...path, name.toString()], additionalHandlers);

--- a/index.ts
+++ b/index.ts
@@ -1,33 +1,3 @@
-export type TypedPathKey = string | symbol | number;
-
-export type TypedPathNode<T> = {
-    $path: string;
-    $raw: TypedPathKey[];
-};
-
-export type TypedPathFunction<T> = (...args: any[]) => T;
-
-export type TypedPathWrapper<T> = (T extends Array<infer Z>
-    ? {
-        [index: number]: TypedPathWrapper<Z>;
-    }
-    : T extends TypedPathFunction<infer RET>
-        ? {
-            (): TypedPathWrapper<RET>;
-        } & {
-            [P in keyof RET]: TypedPathWrapper<RET[P]>;
-        }
-        : {
-            [P in keyof T]: TypedPathWrapper<T[P]>;
-        }
-    ) & TypedPathNode<T>;
-
-const toStringMethods: (string | symbol | number)[] = [
-    'toString',
-    Symbol.toStringTag,
-    'valueOf'
-];
-
 function pathToString(path: string[]): string {
     return path.reduce((current, next) => {
         if (+next === +next) {
@@ -40,22 +10,52 @@ function pathToString(path: string[]): string {
     }, '');
 }
 
-export function typedPath<T>(path: string[] = []): TypedPathWrapper<T> {
-    return <TypedPathWrapper<T>>new Proxy({}, {
+export type TypedPathKey = string | symbol | number;
+
+export type TypedPathFunction<T> = (...args: any[]) => T;
+
+export type TypedPathHandlersConfig = Record<string, <T extends TypedPathHandlersConfig = Record<never, never>>(path: string[], additionalHandlers?: T) => any>;
+
+const defaultHandlersConfig = {
+    $path: (path: string[]) => pathToString(path),
+    $raw: (path: string[]) => path,
+    toString: (path: string[]) => () => pathToString(path),
+    [Symbol.toStringTag]: (path: string[]) => () => pathToString(path),
+    valueOf: (path: string[]) => () => pathToString(path),
+}
+
+export type TypedPathHandlers<T extends TypedPathHandlersConfig> = {
+    [key in keyof T]: ReturnType<T[key]>;
+};
+
+export type TypedPathWrapper<T, TPH extends TypedPathHandlers<Record<never, never>>> = (T extends Array<infer Z>
+    ? {
+        [index: number]: TypedPathWrapper<Z, TPH>;
+    }
+    : T extends TypedPathFunction<infer RET>
+        ? {
+            (): TypedPathWrapper<RET, TPH>;
+        } & {
+            [P in keyof RET]: TypedPathWrapper<RET[P], TPH>;
+        }
+        : {
+            [P in keyof T]: TypedPathWrapper<T[P], TPH>;
+        }
+    ) & TypedPathHandlers<TPH>;
+
+export function typedPath<T, K extends TypedPathHandlersConfig = Record<never, never>>(path: string[] = [], additionalHandlers?: K): TypedPathWrapper<T, K & typeof defaultHandlersConfig> {
+    return <TypedPathWrapper<T, K & typeof defaultHandlersConfig>>new Proxy({}, {
         get(target: T, name: TypedPathKey) {
-            if (name === '$path') {
-                return pathToString(path);
+            const handlersConfig: TypedPathHandlersConfig = { ...(additionalHandlers ?? {}), ...defaultHandlersConfig };
+
+            const keys: (keyof typeof handlersConfig)[] = Object.keys(handlersConfig);
+            for (const key of keys) {
+                if (key === name) {
+                    return handlersConfig[key](path, additionalHandlers);
+                }
             }
 
-            if (name === '$raw') {
-                return path;
-            }
-
-            if (toStringMethods.includes(name)) {
-                return () => pathToString(path);
-            }
-
-            return typedPath([...path, name.toString()]);
+            return typedPath([...path, name.toString()], additionalHandlers);
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "chai": "^3.5.0",
     "husky": "^0.13.1",
     "mocha": "^6.2.0",
-    "ts-node": "8.3.0",
+    "ts-node": "^9.0.0",
     "tslint": "^4.4.2",
-    "typescript": "3.6.4"
+    "typescript": "^4.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,10 +920,10 @@ slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
-source-map-support@^0.5.6:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -1034,16 +1034,16 @@ timed-out@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
 
-ts-node@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
-  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
+ts-node@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
-    yn "^3.0.0"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslint@^4.4.2:
   version "4.4.2"
@@ -1066,10 +1066,10 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 unzip-response@^1.0.2:
   version "1.0.2"
@@ -1196,7 +1196,7 @@ yargs@13.3.0, yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
 
-yn@^3.0.0:
+yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Hey man! Just gotta say, your library is amazing, we're actively using it in our project, thank you for creating it!

I had this little idea to add custom handlers to the path besides `$path`, `$raw` etc.
Basically I've added a second argument to the `typedPath` function that can serve as a handler config. Then you can add as many custom handlers as you'd like.

Short example of how it could be used:
```
const tpHandlers = {
  $abs: (path: string[]) => () => {
    return `/${path.join('/')}`;
  },
  $last: (path: string[]) => (arg?: number) => {
    return path.slice(-(arg ?? 1)).join('/');
  },
  $url: (path: string[]) => () => {
    return path.join('/');
  },
};

export const tp = typedPath<RoutesConfig, typeof tpHandlers>([], tpHandlers);

tp.clients.list.$abs(); //    /clients/list
tp.clients.list.$last(); //   list
tp.clients.list.$url(); //    clients/list
```

I've tested it locally, all the base functions work.

Please take a look, tell me what you think :)