### PR TITLE
Add relative path for nested objects

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ export type TypedPathHandlersConfig = Record<
 
 const defaultHandlersConfig = {
     $path: (path: TypedPathKey[]) => pathToString(path),
+    $relativePath: (path: TypedPathKey[]) => path[path.length - 1],
     /**
      * @deprecated This method transforms all path chunks to strings.
      * If you need the path with numbers and Symbols - use $rawPath


### PR DESCRIPTION
Hi @bsalex.
During development, it is often necessary to retrieve the last key of a nested object. As an example where it would be useful
`<input [formControlName]="formTp.nestedObj.someKey.$relativePath" type="text" class="form-control" />`